### PR TITLE
Feat: use adapter as one-time settlement receiver for connector

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,52 +7,23 @@
 Settlement is an important part of any trust-based ledger. Debts are
 meaningless if there is no way to pay them off.
 
-There are already existing "optimistic plugins" that can listen for real-money
-settlements, and then emit this as an event. A settlement has two parts,
-though. The first part is receipt of real funds, and the second part is
-crediting a trustline/trust-based account.
+This plugin facilitates settlement by getting added to a connector, emitting an incoming
+transfer with an interledger packet, and then getting removed. The connector will see the
+incoming transfer and route it to the proper destination.
 
-`ilp-plugin-settlement-adapter` handles this second step by intercepting incoming transfers
-on a settlement plugin, attaching an ILP header to make sure that the funds are
-routed to credit the right account, and then emitting the transfer.
+Say `example.bob` settled for $3.00. You might use the plugin like so:
 
-Because the ILP header needs to contain the destination amount, and because
-settlements aren't necessarily done over a system where ILP quoting is
-possible, `ilp-plugin-settlement-adapter` uses `ilp-core` to quote incoming payments by
-source amount.
-
-## How do I use this?
-
-`ilp-plugin-settlement-adapter` looks a lot like a normal plugin, in the configuration.
-Say you had an optimistic plugin configured like so:
-
-```js
-CONNECTOR_LEDGERS={
-  // ...
-  "example.red.": {
-    "currency": "USD",
-    "plugin": "ilp-plugin-example",
-    "options": {
-      "username": "alice",
-      "password": "password123"
-    }
-  }
-}
 ```
+const plugin = new SettlementAdapter({
+  amount: '3.00',
+  currency: 'USD',
+  destination: 'example.bob'
+})
 
-To make this use `ilp-plugin-settlement-adapter`, you simply change it to:
+// add plugin to connector ...
 
-```js
-CONNECTOR_LEDGERS={
-  // ...
-  "example.red.": {
-    "currency": "USD",
-    "plugin": "ilp-plugin-settlement-adapter", // this takes the place of the old plugin field
-    "options": {
-      "_plugin": "ilp-plugin-example", // and this becomes the wrapped plugin
-      "username": "alice",
-      "password": "password123"
-    }
-  }
-}
+// emits an payment for 3.00 USD that gets routed to 'example.bob'
+yield plugin.receive()
+
+// remove plugin from connector ...
 ```

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "co": "^4.6.0",
     "debug": "^2.3.3",
     "eventemitter2": "^2.2.1",
-    "ilp-core": "^10.0.0"
+    "ilp-core": "^10.0.0",
+    "uuid4": "^1.0.0"
   },
   "devDependencies": {
     "chai": "^3.5.0",

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,0 +1,42 @@
+'use strict'
+
+const precision = (num) => {
+  const significant = num.replace(/\./, '')
+    .match(/^0*([0-9]+)$/)
+
+  if (!significant) {
+    throw new Error('Invalid amount: "' + num + '"')
+  }
+
+  return significant[1].length
+}
+
+const scale = (num) => {
+  return num.split('.')[1].length
+}
+
+const checkAmount = (amount) => {
+  if (typeof amount !== 'string' || !amount.match(/^[0-9]+(\.[0-9]+)?$/)) {
+    throw new Error('Invalid amount: "' + amount + '"')
+  }
+}
+
+const checkCurrency = (currency) => {
+  if (typeof currency !== 'string' || !currency.match(/^[A-Z]{3}$/)) {
+    throw new Error('Invalid currency: "' + currency + '"')
+  }
+}
+
+const checkDestination = (destination) => {
+  if (typeof destination !== 'string' || !destination.match(/^[a-zA-Z0-9._~-]+$/)) {
+    throw new Error('Invalid destination: "' + destination + '"')
+  }
+}
+
+module.exports = {
+  checkAmount,
+  checkCurrency,
+  checkDestination,
+  precision,
+  scale
+}

--- a/test/indexSpec.js
+++ b/test/indexSpec.js
@@ -1,0 +1,60 @@
+'use strict'
+const assert = require('chai').assert
+const PluginSettlementAdapter = require('..')
+
+describe('PluginSettlementAdapter', function () {
+  beforeEach(function () {
+    this.plugin = new PluginSettlementAdapter({
+      amount: '3.00',
+      currency: 'EUR',
+      destination: 'example.red.bob'
+    })
+  })
+
+  it('should be a class', function () {
+    assert.isFunction(PluginSettlementAdapter)
+  })
+
+  it('should instantiate a plugin', function () {
+    assert.isObject(this.plugin)
+  })
+
+  it('should connect', function () {
+    return this.plugin.connect()
+  })
+
+  it('should be connected', function () {
+    return this.plugin.connect()
+      .then(() => {
+        assert.isTrue(this.plugin.isConnected())
+      })
+  })
+
+  it('should disconnect', function () {
+    return this.plugin.disconnect()
+      .then(() => {
+        assert.isFalse(this.plugin.isConnected())
+      })
+  })
+
+  it('should getInfo', function () {
+    const info = this.plugin.getInfo()
+
+    assert.equal(info.currencyCode, 'EUR')
+    assert.equal(info.currencySymbol, 'EUR')
+    assert.equal(info.precision, 3)
+    assert.equal(info.scale, 2)
+    assert.isOk(info.prefix)
+  })
+
+  it('should getAccount', function () {
+    assert.equal(this.plugin.getAccount(), this.plugin._info.prefix + 'connector')
+  })
+
+  it('should getBalance', function () {
+    return this.plugin.getBalance()
+      .then((balance) => {
+        assert.equal(balance, '0')
+      })
+  })
+})


### PR DESCRIPTION
Instead of wrapping an optimistic ledger plugin, an individual settlement adapter will be created for each settlement.

Some other component needs to listen for settlements and resolve their memos to destinations, but the settlement adapter will still perform the appropriate mocks to quote a payment, construct an ILP packet, and emit it to the connector.